### PR TITLE
fix: add `prover` feature to pico and some ENV settings

### DIFF
--- a/pessimistic-proof-bench/crates/program-pico/Cargo.lock
+++ b/pessimistic-proof-bench/crates/program-pico/Cargo.lock
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -1859,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "p3-circle"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-challenger",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -2030,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -2057,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "rayon",
 ]
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-dft",
@@ -2094,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-commit",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "p3-mersenne-31"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "gcd",
  "p3-field",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-field",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "itertools 0.13.0",
  "p3-air",
@@ -2191,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/Plonky3.git?rev=7192b3e6#7192b3e6c699ab6855eb49fa376a8a0e0321a6d3"
+source = "git+https://github.com/brevis-network/Plonky3.git?rev=9cdbc7c6#9cdbc7c633d6671853d102dbb8d78e81d99566bc"
 dependencies = [
  "serde",
 ]
@@ -2332,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "pico-derive"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/pico#0143796d9618251d619b3badf1afb64fb32c1b4c"
+source = "git+https://github.com/brevis-network/pico#286feb9878d9e09347852e5bf127b8ff81a2b45c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2341,8 +2341,8 @@ dependencies = [
 
 [[package]]
 name = "pico-patch-libs"
-version = "1.0.0"
-source = "git+https://github.com/brevis-network/pico#0143796d9618251d619b3badf1afb64fb32c1b4c"
+version = "1.0.1"
+source = "git+https://github.com/brevis-network/pico#286feb9878d9e09347852e5bf127b8ff81a2b45c"
 dependencies = [
  "bincode",
  "serde",
@@ -2350,8 +2350,8 @@ dependencies = [
 
 [[package]]
 name = "pico-sdk"
-version = "1.0.0"
-source = "git+https://github.com/brevis-network/pico#0143796d9618251d619b3badf1afb64fb32c1b4c"
+version = "1.0.1"
+source = "git+https://github.com/brevis-network/pico#286feb9878d9e09347852e5bf127b8ff81a2b45c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2376,8 +2376,8 @@ dependencies = [
 
 [[package]]
 name = "pico-vm"
-version = "1.0.0"
-source = "git+https://github.com/brevis-network/pico#0143796d9618251d619b3badf1afb64fb32c1b4c"
+version = "1.0.1"
+source = "git+https://github.com/brevis-network/pico#286feb9878d9e09347852e5bf127b8ff81a2b45c"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/pessimistic-proof-bench/crates/test-pico/.env
+++ b/pessimistic-proof-bench/crates/test-pico/.env
@@ -1,0 +1,5 @@
+export CHUNK_SIZE=4194304
+export CHUNK_BATCH_SIZE=32
+export SPLIT_THRESHOLD=1048576
+export RUSTFLAGS="-C target-cpu=native -C target-feature=+avx512f,+avx512ifma,+avx512vl"
+export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"

--- a/pessimistic-proof-bench/crates/test-pico/Cargo.toml
+++ b/pessimistic-proof-bench/crates/test-pico/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "1.11.0", features = ["v4", "fast-rng"] }
 regex = "1.11"
 serde_cbor = "0.11.2"
 
-pico-sdk = { git = "https://github.com/brevis-network/pico" }
+pico-sdk = { git = "https://github.com/brevis-network/pico", features = ["prover"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/pessimistic-proof-bench/crates/test-pico/Cargo.toml
+++ b/pessimistic-proof-bench/crates/test-pico/Cargo.toml
@@ -7,6 +7,11 @@ edition.workspace = true
 name = "ppgen"
 path = "src/bin/ppgen.rs"
 
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+
 [dependencies]
 agglayer-primitives.workspace = true
 agglayer-types = { path = "../agglayer-types", features = ["testutils"] }


### PR DESCRIPTION
Hi, great work for the openvm benchmarks!

I try to add [prover](https://github.com/brevis-network/pico/blob/main/sdk/sdk/Cargo.toml#L35) feature of pico and some ENV for benchmark settings:
- According to pico zkvm-bench [run.sh](https://github.com/brevis-network/zkvm-bench/blob/main/pico/run.sh#L6), it has multiple ENVs to optimize the benchmark. I add these ENVs to `.env` file, we may need to ensure setting these ENVs when benching pico.
- The [prover](https://github.com/brevis-network/pico/blob/main/sdk/sdk/Cargo.toml#L35) feature enables the `jemalloc` allocator, it may makes some optimization.
